### PR TITLE
Fix transitive dependencies in non-linux

### DIFF
--- a/util/psutil.go
+++ b/util/psutil.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package util
 
 import (

--- a/util/psutil_notlinux.go
+++ b/util/psutil_notlinux.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package util
+
+func GetTmpPath(pid int) string                                    { return "" }
+func GetProcessInfo(pid int, uid *int, gid *int, nspid *int) error { return nil }
+func EnterNS(pid int, nsType string) int                           { return 0 }

--- a/util/ptrace.go
+++ b/util/ptrace.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package util
 
 import (
@@ -7,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 const maxAttachRetries = 5
@@ -20,7 +20,7 @@ type JavaProgram struct {
 }
 
 func waitPid(pid int) error {
-	ret, err := unix.Wait4(pid, nil, unix.WALL, nil)
+	ret, err := syscall.Wait4(pid, nil, syscall.WALL, nil)
 
 	if err != nil {
 		return err

--- a/util/ptrace_notlinux.go
+++ b/util/ptrace_notlinux.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package util
+
+type JavaProgram struct{}
+
+func AttachToJavaProgram(fileInfo *FileInfo) (*JavaProgram, error)                    { return nil, nil }
+func (p *JavaProgram) DetachFromJavaProgram() error                                   { return nil }
+func (p *JavaProgram) ReadMemoryIntoBuf(address uintptr, buf []byte, size int) error  { return nil }
+func (p *JavaProgram) WriteBufInfoMemory(address uintptr, buf []byte, size int) error { return nil }
+func (p *JavaProgram) ReadMemory(address uintptr, size int) ([]byte, error)           { return nil, nil }
+func (p *JavaProgram) ReadUint64(address uintptr) (uint64, error)                     { return 0, nil }
+func (p *JavaProgram) ReadSymbolValues(syms map[string]uintptr) (map[string]uint64, error) {
+	return nil, nil
+}


### PR DESCRIPTION
OBI verification tasks, in non-linux environments, started to complain about a transitive dependency to this packet, so I made it compilable in non-linux.

It also replaces `golang.org/x/sys` by `syscall` in order to simplify go.mod dependencies.